### PR TITLE
fix: Use COPY instead of ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM webpagetest/server
-ADD locations.ini /var/www/html/settings/
+COPY locations.ini /var/www/html/settings/


### PR DESCRIPTION
Docker's `ADD` is a general purpose tool that includes some magic for handling URLs. When those extras aren't needed, prefer `COPY`.